### PR TITLE
ensure metadata are strings

### DIFF
--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -225,6 +225,15 @@ if __name__ == "__main__":
 			# prepare PDF metadata
 			# sometimes archive metadata is missing
 			pdfmeta = { }
+			# ensure metadata are str
+			for key in ["title", "creator", "associated-names"]:
+				if key in metadata:
+					if isinstance(metadata[key], str):
+						pass
+					elif isinstance(metadata[key], list):
+						metadata[key] = "; ".join(metadata[key])
+					else:
+						raise Exception("unsupported metadata type")
 			# title
 			if 'title' in metadata:
 				pdfmeta['title'] = metadata['title']


### PR DESCRIPTION
some items (e.g. chaosfractalsnew00peit)
have a list of authors
rather than a single author string

before this commit:
all seems ok when generating the pdf with img2pdf, but the pdf's author information is not visible using pdfinfo and later when using ocrmypdf a fatal error occurs at the end:
```
NotImplementedError: don't know how to __str__ this object
```

after this commit:
if metadata items are lists,
they are joined into a single string
separated by "; ",
and pdfinfo and ocrmypdf work as expected